### PR TITLE
Implement notion of convergence across Behaviors

### DIFF
--- a/src/QuorumTools/Control.hs
+++ b/src/QuorumTools/Control.hs
@@ -1,20 +1,25 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module QuorumTools.Control where
 
 import           Control.Concurrent.Async     (Async)
 import           Control.Concurrent.MVar      (newEmptyMVar, takeMVar,
                                                tryPutMVar)
-import           Control.Concurrent.STM       (atomically)
+import           Control.Concurrent.STM       (STM, atomically)
 import           Control.Concurrent.STM.TChan (TChan, dupTChan, newTChan,
                                                readTChan, writeTChan)
 import           Control.Concurrent.STM.TMVar (TMVar, newTMVar, putTMVar,
-                                               readTMVar, takeTMVar)
+                                               readTMVar, swapTMVar, takeTMVar)
 import           Control.Exception            (bracket)
+import           Control.Monad                (forever, (<$!>))
 import           Control.Monad.Loops          (untilJust)
 import           Control.Monad.Managed        (MonadManaged)
-import           Data.Foldable                (traverse_)
-import           Data.Maybe                   (fromMaybe)
+import           Data.Foldable                (for_, toList, traverse_)
+import           Data.Maybe                   (fromJust, fromMaybe)
+import           Data.Vector                  (Vector)
+import qualified Data.Vector                  as V
 import           Turtle                       (Fold (..), MonadIO, fork, liftIO,
                                                void, wait)
 
@@ -52,31 +57,94 @@ event e = do
   let fire = void $ tryPutMVar mvar e
   pure (occurred, fire)
 
--- | Creates a stream of values for a many publishers to update, and many
+-- | Creates a stream of values for many publishers to update, and many
 -- consumers to subscribe (to value changes) or observe the current value.
 behavior :: (MonadIO m) => m (Behavior a)
 behavior = liftIO $ atomically $ Behavior <$> newTChan <*> newTMVar Nothing
 
 transition' :: MonadIO m => Behavior a -> (Maybe a -> a) -> m ()
 transition' (Behavior tc tm) f = liftIO $ atomically $ do
-  prev <- takeTMVar tm
-  let next = f prev
-  putTMVar tm $ Just next
-  writeTChan tc next
+  v <- takeTMVar tm
+  let v' = f v
+  putTMVar tm $ Just v'
+  writeTChan tc v'
 
 transition :: (MonadIO m, Monoid a) => Behavior a -> (a -> a) -> m ()
 transition b f = transition' b (f . fromMaybe mempty)
 
-subscribe :: MonadIO m => Behavior a -> m (TChan a)
-subscribe (Behavior chan _) = liftIO $ atomically $ dupTChan chan
+subscribe' :: Behavior a -> STM (TChan a)
+subscribe' (Behavior chan _) = dupTChan chan
 
-observe' :: MonadIO m => Behavior a -> m (Maybe a)
-observe' (Behavior _ mvar) = liftIO $ atomically $ readTMVar mvar
+subscribe :: MonadIO m => Behavior a -> m (TChan a)
+subscribe = liftIO . atomically . subscribe'
+
+observe' :: Behavior a -> STM (Maybe a)
+observe' (Behavior _ mvar) = readTMVar mvar
 
 observe :: (MonadIO m, Monoid a) => Behavior a -> m a
-observe = fmap (fromMaybe mempty) . observe'
+observe = fmap (fromMaybe mempty) . liftIO . atomically . observe'
 
 watch :: MonadManaged m => Behavior a -> (a -> Maybe b) -> m (Async b)
 watch b decide = do
   chan <- subscribe b
   fork $ liftIO $ untilJust $ decide <$> atomically (readTChan chan)
+
+nextFrom :: MonadManaged m => Behavior a -> m (Async a)
+nextFrom b = watch b Just
+
+-- forkReplication :: MonadManaged m => forall r. (a -> IO b) -> Behavior a -> Behavior b -> m (Async r)
+-- forkReplication act upstream downstream = fork $ do
+--   chan <- subscribe upstream
+--   forever $ do
+--     val <- atomically $ readTChan chan
+--     val' <- act val
+--     transition' downstream (const val')
+
+mapB :: (MonadManaged m) => (a -> b) -> Behavior a -> m (Behavior b)
+mapB f upstream = do
+    downstream <- behavior
+    void $ forkReplication downstream
+    return downstream
+
+  where
+    forkReplication downstream@(Behavior _ downstreamTm) = fork $ do
+      chan <- atomically $ do
+        mv0 <- observe' upstream
+        void $ swapTMVar downstreamTm (f <$!> mv0)
+        subscribe' upstream
+      forever $ do
+        val <- atomically $ readTChan chan
+        -- NOTE: we publish downstream asychronously here
+        let val' = f $! val
+        transition' downstream (const val')
+
+-- -- | When any of the input behaviors post a new value, the output behavior will
+-- -- post that value. In theory we could implement a simple 'merge' which works
+-- -- over two 'Behavior's then implement this function in terms of that, but our
+-- -- "FRP" implementation is not so efficient, so we don't have that luxury.
+-- merged :: (MonadManaged m, Foldable f) => f (Behavior a) -> m (Behavior a)
+-- merged upstreams = do
+--   downstream <- behavior
+--   for_ upstreams $ \upstream ->
+--     forkReplication pure upstream downstream
+--   return downstream
+
+combine :: forall a m t. (MonadManaged m, Traversable t)
+        => t (Behavior a)
+        -> m (Behavior (Vector (Maybe a)))
+combine upstreams = do
+    downstream <- behavior
+    startReplication downstream
+    return downstream
+
+  where
+    startReplication :: Behavior (Vector (Maybe a)) -> m ()
+    startReplication downstream@(Behavior _ downstreamTm) = do
+      chans <- fmap toList $ liftIO $ atomically $ do
+        mv0s <- traverse observe' upstreams
+        void $ swapTMVar downstreamTm $ Just $ V.fromList $ toList mv0s
+        traverse subscribe' upstreams
+      for_ (zip [(0 :: Int)..] chans) $ \(i, chan) -> fork $ forever $ do
+        val <- atomically $ readTChan chan
+        -- NOTE: we publish downstream asychronously here
+        transition' downstream $ (V.// [(i, Just val)]) . fromJust

--- a/src/QuorumTools/Control.hs
+++ b/src/QuorumTools/Control.hs
@@ -18,7 +18,7 @@ import           Control.Monad                (forever, (<$!>))
 import           Control.Monad.Loops          (untilJust)
 import           Control.Monad.Managed        (Managed, MonadManaged, with)
 import           Data.Foldable                (for_, toList, traverse_)
-import           Data.Maybe                   (fromJust, fromMaybe)
+import           Data.Maybe                   (fromJust)
 import           Data.Monoid.Same             (allSame_)
 import           Data.Time.Units              (TimeUnit, toMicroseconds)
 import           Data.Vector                  (Vector)
@@ -84,8 +84,8 @@ subscribe = liftIO . atomically . subscribe'
 observe' :: Behavior a -> STM (Maybe a)
 observe' (Behavior _ mvar) = readTMVar mvar
 
-observe :: (MonadIO m, Monoid a) => Behavior a -> m a
-observe = fmap (fromMaybe mempty) . liftIO . atomically . observe'
+observe :: (MonadIO m) => Behavior a -> m (Maybe a)
+observe = liftIO . atomically . observe'
 
 watch :: MonadManaged m => Behavior a -> (a -> Maybe b) -> m (Async b)
 watch b decide = do

--- a/src/QuorumTools/Control.hs
+++ b/src/QuorumTools/Control.hs
@@ -171,3 +171,8 @@ convergence time upstreams = do
 
     unsafeDischargeManaged :: Managed r -> IO r
     unsafeDischargeManaged = flip with pure
+
+timeLimit :: (MonadManaged m, TimeUnit t) => t -> Async a -> m (Async (Maybe a))
+timeLimit duration future = do
+  timeout <- timer duration
+  fork $ either (const Nothing) Just <$> waitEitherCancel timeout future

--- a/src/QuorumTools/Observing.hs
+++ b/src/QuorumTools/Observing.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 
 module QuorumTools.Observing where
 
-import qualified Data.Map.Strict            as Map
-import           Data.Monoid                (Last, (<>))
-import           Data.Set                   (Set)
-import qualified Data.Set                   as Set
-import           Data.Text                  (Text, isInfixOf, pack)
-import qualified Data.Text                  as T
-import           Prelude                    hiding (FilePath, lines)
-import           Turtle                     hiding (env, view)
+import qualified Data.Map.Strict        as Map
+import           Data.Monoid            (Last, (<>))
+import           Data.Set               (Set)
+import qualified Data.Set               as Set
+import           Data.Text              (Text, isInfixOf, pack)
+import qualified Data.Text              as T
+import           Prelude                hiding (FilePath, lines)
+import           Turtle                 hiding (env, view)
 
 import           QuorumTools.Checkpoint
-import           QuorumTools.Types          hiding (lastBlock, lastRaftStatus)
-import           QuorumTools.Util           (matchOnce)
+import           QuorumTools.Types      hiding (lastBlock, lastRaftStatus)
+import           QuorumTools.Util       (matchOnce)
 
 -- | Helper for the most common (only) use case for matchCheckpoint.
 matchCheckpoint' :: Checkpoint a -> Text -> (a -> IO ()) -> IO ()

--- a/src/QuorumTools/Observing.hs
+++ b/src/QuorumTools/Observing.hs
@@ -5,8 +5,7 @@
 module QuorumTools.Observing where
 
 import qualified Data.Map.Strict        as Map
-import           Data.Maybe             (fromMaybe)
-import           Data.Monoid            (Last, getLast)
+import           Data.Monoid            (Last)
 import           Data.Set               (Set)
 import qualified Data.Set               as Set
 import           Data.Text              (Text, isInfixOf, pack)
@@ -16,7 +15,7 @@ import           Turtle                 hiding (env, view)
 
 import           QuorumTools.Checkpoint
 import           QuorumTools.Types      hiding (lastBlock, lastRaftStatus)
-import           QuorumTools.Util       (matchOnce)
+import           QuorumTools.Util       (matchOnce, lastOrEmpty)
 
 -- | Helper for the most common (only) use case for matchCheckpoint.
 matchCheckpoint' :: Checkpoint a -> Text -> (a -> IO ()) -> IO ()
@@ -47,9 +46,6 @@ observingLastBlock updateLastBlock = observingLines $ \line ->
     blockPattern :: Pattern Block
     blockPattern = has $
       Block . pack <$> ("Successfully extended chain: " *> count 64 hexDigit)
-
-lastOrEmpty :: Monoid a => Last a -> a
-lastOrEmpty = fromMaybe mempty . getLast
 
 observingTxes
   :: ((Last OutstandingTxes -> OutstandingTxes) -> IO ())

--- a/src/QuorumTools/Observing.hs
+++ b/src/QuorumTools/Observing.hs
@@ -6,7 +6,6 @@ module QuorumTools.Observing where
 
 import qualified Data.Map.Strict        as Map
 import           Data.Maybe             (fromMaybe)
-import           Data.Monoid            (Last)
 import           Data.Set               (Set)
 import qualified Data.Set               as Set
 import           Data.Text              (Text, isInfixOf, pack)
@@ -35,12 +34,12 @@ observingBoot trigger = observingLines $ \line ->
   when ("IPC endpoint opened:" `isInfixOf` line) trigger
 
 observingLastBlock
-  :: ((Maybe (Last Block) -> Last Block) -> IO ())
+  :: ((Maybe Block -> Block) -> IO ())
   -> Shell Line
   -> Shell Line
 observingLastBlock updateLastBlock = observingLines $ \line ->
     case matchOnce blockPattern line of
-      Just latest -> updateLastBlock $ const $ pure latest
+      Just latest -> updateLastBlock $ const latest
       _           -> pure ()
 
   where
@@ -62,12 +61,12 @@ observingTxes updateOutstanding updateAddrs = observingLines $ \line -> do
       updateOutstanding (OutstandingTxes . Set.delete tx . unOutstandingTxes . fromMaybe mempty)
 
 observingRaftStatus
-  :: ((Maybe (Last RaftStatus) -> Last RaftStatus) -> IO ())
+  :: ((Maybe RaftStatus -> RaftStatus) -> IO ())
   -> Shell Line
   -> Shell Line
 observingRaftStatus updateRaftStatus = observingLines $ \line ->
     case matchOnce statusPattern line of
-      Just raftStatus -> liftIO $ updateRaftStatus $ const $ pure raftStatus
+      Just raftStatus -> liftIO $ updateRaftStatus $ const raftStatus
       _               -> pure ()
 
   where

--- a/src/QuorumTools/Test/Outline.hs
+++ b/src/QuorumTools/Test/Outline.hs
@@ -267,12 +267,12 @@ existingMember `addsNode` newcomer = do
     Right _raftId -> return ()
 
 removesNode :: Geth -> Geth -> TestM ()
-existingMember `removesNode` newcomer = do
-  let message = "removing node " <> T.pack (show (gId (gethId newcomer)))
+existingMember `removesNode` target = do
+  let message = "removing node " <> T.pack (show (gId (gethId target)))
   timestampedMessage $ "waiting before " <> message
   td 2
   timestampedMessage message
-  result <- removeNode existingMember (gethId newcomer)
+  result <- removeNode existingMember (gethId target)
   case result of
     Left _err -> throwError RemoveNodeFailure
     Right () -> return ()

--- a/src/QuorumTools/Test/Outline.hs
+++ b/src/QuorumTools/Test/Outline.hs
@@ -22,6 +22,8 @@ import           Data.Text                (Text, pack)
 import qualified Data.Text                as T
 import qualified Data.Text.IO             as T
 import           Data.Time                (getZonedTime, formatTime, defaultTimeLocale)
+import           Data.Time.Units          (Second)
+import           Data.Vector              (Vector)
 import qualified QuorumTools.IpTables     as IPT
 import qualified QuorumTools.PacketFilter as PF
 import           Prelude                  hiding (FilePath)
@@ -31,7 +33,7 @@ import           Turtle
 import QuorumTools.Client
 import QuorumTools.Cluster
 import QuorumTools.Constellation
-import QuorumTools.Control (Behavior, awaitAll, observe)
+import QuorumTools.Control (Behavior, awaitAll, observe, awaitConvergence)
 import QuorumTools.Types
 
 newtype TestNum = TestNum { unTestNum :: Int } deriving (Enum, Num)
@@ -270,3 +272,9 @@ existingMember `removesNode` newcomer = do
   case result of
     Left _err -> throwError RemoveNodeFailure
     Right () -> return ()
+
+raftConvergence :: (MonadManaged m, Traversable t)
+                => t NodeInstrumentation
+                -> m (Async (Either (Vector (Last Block))
+                                            (Vector Block)))
+raftConvergence = awaitConvergence (1 :: Second) . fmap lastBlock

--- a/src/QuorumTools/Test/Raft/PrivateStateTest.hs
+++ b/src/QuorumTools/Test/Raft/PrivateStateTest.hs
@@ -12,7 +12,7 @@ import           QuorumTools.Types
 
 privateStateTestMain :: IO ()
 privateStateTestMain = testNTimes 1 PrivacyEnabled (NumNodes 3) $ \iNodes -> do
-  let [g1, g2, g3] = fst <$> iNodes
+  let ([g1, g2, g3], instruments) = unzip iNodes
       (_, geth1Instruments) = head iNodes
 
   -- geth1 and geth3 are both party to this tx, but geth2 is not
@@ -25,7 +25,7 @@ privateStateTestMain = testNTimes 1 PrivacyEnabled (NumNodes 3) $ \iNodes -> do
   let increments = 5
   replicateM_ increments $ incrementStorage g1 privStorage privStorageAddr
 
-  td 2
+  awaitBlockConvergence instruments
 
   let expectedPrivateValue = 42 + increments
 

--- a/src/QuorumTools/Test/Raft/PublicStateTest.hs
+++ b/src/QuorumTools/Test/Raft/PublicStateTest.hs
@@ -16,6 +16,7 @@ publicStateTestMain = testNTimes 1 PrivacyDisabled (NumNodes 3) $ \iNodes -> do
       geths = fst <$> iNodes
       sendTo = cycle geths
       contract = simpleStorage Public
+      instruments = snd <$> iNodes
 
   storageAddr <- createContract geth1 contract (txAddrs geth1Instruments)
 
@@ -24,7 +25,7 @@ publicStateTestMain = testNTimes 1 PrivacyDisabled (NumNodes 3) $ \iNodes -> do
   forM_ (take increments sendTo) $ \geth ->
     incrementStorage geth contract storageAddr
 
-  td 2
+  awaitBlockConvergence instruments
 
   let expectedValue = 42 + increments
 

--- a/src/QuorumTools/Test/Raft/RestartNodeTest.hs
+++ b/src/QuorumTools/Test/Raft/RestartNodeTest.hs
@@ -5,7 +5,7 @@ module QuorumTools.Test.Raft.RestartNodeTest where
 
 import           Control.Concurrent.Async (Concurrently (..))
 import           Control.Lens             ((.~))
-import           Data.Monoid              (Last)
+import           Data.Maybe               (fromMaybe)
 import           Turtle
 
 import           QuorumTools.Cluster
@@ -22,7 +22,7 @@ waitForElection instruments = do
   _ <- wait (assumedRole instruments)
   timestampedMessage "initial election succeeded"
 
-type NodeInfo = (Last Block, OutstandingTxes)
+type NodeInfo = (Maybe Block, OutstandingTxes)
 
 refine :: Either FailureReason a -> IO a
 refine (Left failure) = print failure >> exit failedTestCode
@@ -31,7 +31,7 @@ refine (Right a)      = pure a
 readNodeInfo :: Either FailureReason NodeInstrumentation -> IO NodeInfo
 readNodeInfo = refine >=> \instruments -> (,)
   <$> observe (lastBlock instruments)
-  <*> observe (outstandingTxes instruments)
+  <*> fmap (fromMaybe mempty) (observe (outstandingTxes instruments))
 
 --   seconds  |   spammer    |    node 1    |    nodes 2 / 3
 -- ---------------------------------------------------------

--- a/src/QuorumTools/Test/Raft/RestartNodeTest.hs
+++ b/src/QuorumTools/Test/Raft/RestartNodeTest.hs
@@ -6,6 +6,7 @@ module QuorumTools.Test.Raft.RestartNodeTest where
 import           Control.Concurrent.Async (Concurrently (..))
 import           Control.Lens             ((.~))
 import           Data.Maybe               (fromMaybe)
+import           Data.Monoid              (Last, getLast)
 import           Turtle
 
 import           QuorumTools.Cluster
@@ -22,7 +23,7 @@ waitForElection instruments = do
   _ <- wait (assumedRole instruments)
   timestampedMessage "initial election succeeded"
 
-type NodeInfo = (Maybe Block, OutstandingTxes)
+type NodeInfo = (Last Block, OutstandingTxes)
 
 refine :: Either FailureReason a -> IO a
 refine (Left failure) = print failure >> exit failedTestCode
@@ -31,7 +32,7 @@ refine (Right a)      = pure a
 readNodeInfo :: Either FailureReason NodeInstrumentation -> IO NodeInfo
 readNodeInfo = refine >=> \instruments -> (,)
   <$> observe (lastBlock instruments)
-  <*> fmap (fromMaybe mempty) (observe (outstandingTxes instruments))
+  <*> fmap (fromMaybe mempty . getLast) (observe (outstandingTxes instruments))
 
 --   seconds  |   spammer    |    node 1    |    nodes 2 / 3
 -- ---------------------------------------------------------

--- a/src/QuorumTools/Test/Raft/RestartNodeTest.hs
+++ b/src/QuorumTools/Test/Raft/RestartNodeTest.hs
@@ -5,14 +5,14 @@ module QuorumTools.Test.Raft.RestartNodeTest where
 
 import           Control.Concurrent.Async (Concurrently (..))
 import           Control.Lens             ((.~))
-import           Data.Maybe               (fromMaybe)
-import           Data.Monoid              (Last, getLast)
+import           Data.Monoid              (Last)
 import           Turtle
 
 import           QuorumTools.Cluster
 import           QuorumTools.Control
 import           QuorumTools.Test.Outline
 import           QuorumTools.Types
+import           QuorumTools.Util         (lastOrEmpty)
 
 numNodes :: Int
 numNodes = 3
@@ -32,7 +32,7 @@ refine (Right a)      = pure a
 readNodeInfo :: Either FailureReason NodeInstrumentation -> IO NodeInfo
 readNodeInfo = refine >=> \instruments -> (,)
   <$> observe (lastBlock instruments)
-  <*> fmap (fromMaybe mempty . getLast) (observe (outstandingTxes instruments))
+  <*> fmap lastOrEmpty (observe (outstandingTxes instruments))
 
 --   seconds  |   spammer    |    node 1    |    nodes 2 / 3
 -- ---------------------------------------------------------

--- a/src/QuorumTools/Types.hs
+++ b/src/QuorumTools/Types.hs
@@ -12,7 +12,6 @@ import           Data.Aeson               (FromJSON (parseJSON),
                                            ToJSON (toJSON), Value (String))
 import           Data.Aeson.Types         (typeMismatch)
 import           Data.Map.Strict          (Map)
-import           Data.Monoid              (Last)
 import           Data.Set                 (Set)
 import           Data.String
 import           Data.Text                (Text)
@@ -214,8 +213,8 @@ data AllConnected = AllConnected
 data NodeInstrumentation = NodeInstrumentation
   { nodeOnline      :: Async NodeOnline
   , nodeTerminated  :: Async NodeTerminated
-  , lastBlock       :: Behavior (Last Block)
-  , lastRaftStatus  :: Behavior (Last RaftStatus)
+  , lastBlock       :: Behavior Block
+  , lastRaftStatus  :: Behavior RaftStatus
   , outstandingTxes :: Behavior OutstandingTxes
   , txAddrs         :: Behavior TxAddrs
   , allConnected    :: Async AllConnected

--- a/src/QuorumTools/Util.hs
+++ b/src/QuorumTools/Util.hs
@@ -11,19 +11,19 @@ import           Data.ByteString         (ByteString)
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Base16  as B16
 import qualified Data.ByteString.Char8   as B8
-import           Data.Monoid             ((<>))
+import           Data.Maybe              (fromMaybe)
+import           Data.Monoid             (Last, (<>), getLast)
 import           Data.Text               (Text)
 import qualified Data.Text               as T
 import qualified Data.Text.Encoding      as T
 import qualified Data.Text.IO            as T
-import           System.IO               (BufferMode (..), hSetBuffering)
 import           Data.Text.Lazy          (fromStrict, toStrict)
 import qualified Data.Text.Lazy.Encoding as LT
-import           Numeric                 (showHex, readHex)
+import           Numeric                 (readHex, showHex)
 import           Prelude                 hiding (FilePath, lines)
+import           System.IO               (BufferMode (..), hSetBuffering)
 import           Turtle                  hiding (bytes, prefix, text)
-import           Turtle.Pattern          (Pattern, count, hexDigit, skip,
-                                          match)
+import           Turtle.Pattern          (Pattern, count, hexDigit, match, skip)
 
 inshellWithJoinedErr :: Text -> Shell Line -> Shell Line
 inshellWithJoinedErr cmd inputShell = do
@@ -157,3 +157,6 @@ toInt h = case readHex (B8.unpack (fromHex h)) of
 
 hexPrefixed :: Hex a => a -> Text
 hexPrefixed = printHex WithPrefix
+
+lastOrEmpty :: Monoid a => Last a -> a
+lastOrEmpty = fromMaybe mempty . getLast


### PR DESCRIPTION
- Move use of `Last` `Monoid` into impl of `Behavior`
- Add `mapB`, `combine`, and `convergence` combinators, the latter reporting whether `combine`d `Behavior`s have correctly converged on a single value after a tunable timeout. Whenever a new value comes in from any of the underlying `Behavior`s, we restart the timeout.
- Switch public/private state tests to use higher-level test DSL method `awaitBlockConvergence`
- Now it will be easy to add convergence detection for, e.g. raft terms after adding/removing nodes to/from a cluster.