### PR TITLE
Remove cabal reference to Genesis.Contract.

### DIFF
--- a/quorum-tools.cabal
+++ b/quorum-tools.cabal
@@ -50,7 +50,6 @@ library
     QuorumTools.Constellation
     QuorumTools.Control
     QuorumTools.Genesis
-    QuorumTools.Genesis.Contract
     QuorumTools.IpTables
     QuorumTools.Mains.LocalNew
     QuorumTools.Mains.LocalSpam


### PR DESCRIPTION
Left over from my removal of QuorumChain the other day.